### PR TITLE
Update virtual_server.go

### DIFF
--- a/cmd/virtual_server.go
+++ b/cmd/virtual_server.go
@@ -141,7 +141,7 @@ func createVirtualServer(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	vm.CpuCores, err = cmd.Flags().GetInt("cpuCores")
+	vm.CpuCores, err = cmd.Flags().GetInt("cpu-cores")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fixes "Error: flag accessed but not defined: cpuCores" error.